### PR TITLE
Befunge-93: Fix helloworld to avoid null byte at end

### DIFF
--- a/languages/befunge93/constants.ts
+++ b/languages/befunge93/constants.ts
@@ -57,8 +57,8 @@ export enum Bfg93Op {
 
 /** Sample program printing "Hello world" */
 export const sampleProgram = [
-  `"!dlroW ,olleH">:v`,
-  `               |,<`,
+  `"!dlroW ,olleH">,v`,
+  `               |:<`,
   `               @`,
 ].join("\n");
 

--- a/languages/befunge93/tests/samples/helloworld.txt
+++ b/languages/befunge93/tests/samples/helloworld.txt
@@ -1,3 +1,3 @@
-"!dlroW ,olleH">:v
-               |,<
+"!dlroW ,olleH">,v
+               |:<
                @


### PR DESCRIPTION
No longer prints extra null character at the end of the string. Closes #10 