### PR TITLE
Add zero-sleep execution with debounced rendering

### DIFF
--- a/ui/execution-controls.tsx
+++ b/ui/execution-controls.tsx
@@ -38,7 +38,7 @@ const IntervalInput = (props: {
   return (
     <div style={styles.inputWrapper}>
       <NumericInput
-        min={5}
+        min={0}
         stepSize={5}
         defaultValue={20}
         minorStepSize={null}

--- a/ui/renderer-wrapper.tsx
+++ b/ui/renderer-wrapper.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { LanguageProvider } from "../languages/types";
 
+const RENDER_INTERVAL_MS = 50;
+
 export interface RendererRef<RS> {
   /** Update runtime state to renderer */
   updateState: (state: RS | null) => void;
@@ -9,19 +11,46 @@ export interface RendererRef<RS> {
 /**
  * React component that acts as an imperatively controller wrapper
  * around the actual language renderer. This is to pull renderer state updates
- * outside of Mainframe for performance reasons.
+ * outside of Mainframe and debouncing rerenders for performance reasons.
  */
 const RendererWrapperComponent = <RS extends {}>(
   { renderer }: { renderer: LanguageProvider<RS>["Renderer"] },
   ref: React.Ref<RendererRef<RS>>
 ) => {
-  const [state, setState] = React.useState<RS | null>(null);
+  const [renderedState, setRenderedState] = React.useState<RS | null>(null);
 
-  React.useImperativeHandle(ref, () => ({
-    updateState: setState,
-  }));
+  /**
+   * Re-rendering on each state update becomes a bottleneck for running code at high speed.
+   * The main browser thread will take too much time handling each message and the message queue
+   * will pile up, leading to very visible delay in actions like pause and stop.
+   *
+   * To avoid this, we do some debouncing here. We only truly re-render at every X ms: on
+   * other updates we just store the latest state in a ref.
+   */
 
-  return renderer({ state });
+  // Timer for re-rendering with the latest state
+  const debounceTimerRef = React.useRef<NodeJS.Timeout | null>(null);
+  // Ref to store the very latest state, that may be rendered upto X ms later
+  const latestState = React.useRef<RS | null>(null);
+
+  /**
+   * Update the current renderer state. Debounces re-render by default,
+   * pass `immediate` as true to immediately re-render with the given state.
+   */
+  const updateState = (state: RS | null) => {
+    latestState.current = state;
+    if (debounceTimerRef.current) return; // Timeout will automatically render liveState
+
+    // Set a timer to re-render with the latest result after X ms
+    debounceTimerRef.current = setTimeout(() => {
+      setRenderedState(latestState.current);
+      debounceTimerRef.current = null;
+    }, RENDER_INTERVAL_MS);
+  };
+
+  React.useImperativeHandle(ref, () => ({ updateState }));
+
+  return renderer({ state: renderedState });
 };
 
 export const RendererWrapper = React.forwardRef(RendererWrapperComponent);


### PR DESCRIPTION
Enable superfast execution mode at 0ms interval. This removes (almost) all sleep from the execution side if the user sets the execution interval to 0ms.

Some periodic sleep is required, otherwise worker-side message handlers (for user actions like pause, stop) won't get a chance to trigger as the call stack will be busy with the execution loop. But sleep has a pretty good overhead - program execution performance with sleep(0) is similar to sleep(5). As a middle ground, for 0ms execution, we still do a sleep(0) after every 10ms. This preserves performance and allows user action as well.

Debouncing re-renders of the runtime state renderer is also required, as otherwise the main thread will fall behind in processing worker messages in time.

Fixes #9 